### PR TITLE
Fix referer retrieval bug

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -21,8 +21,6 @@ import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 
 import javax.enterprise.context.RequestScoped;
@@ -94,19 +92,11 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-	    String referer = request.getHeader("Referer");
-	    checkState(referer != null, "The Referer header was not specified");
-	    
-	    String refererPath = referer;
-		try {
-		    refererPath = new URL(referer).getPath();
-		} catch(MalformedURLException e) {
-		    //Maybe a relative path?
-		    refererPath = referer;
-		}
+		String referer = request.getHeader("Referer");
+		checkState(referer != null, "The Referer header was not specified");
 
 		String path = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(path) + path.length());
+		return referer.substring(referer.indexOf(path) + path.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -21,6 +21,8 @@ import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 
 import javax.enterprise.context.RequestScoped;
@@ -95,8 +97,15 @@ public class DefaultRefererResult implements RefererResult {
 		String referer = request.getHeader("Referer");
 		checkState(referer != null, "The Referer header was not specified");
 
-		String path = request.getContextPath();
-		return referer.substring(referer.indexOf(path) + path.length());
+		String refererPath= null;
+		try {
+			refererPath = new URL(referer).getPath();
+		} catch(MalformedURLException e) {
+			//Maybe a relative path?
+			refererPath = referer;
+		}
+		String ctxPath = request.getContextPath();
+		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -105,7 +105,10 @@ public class DefaultRefererResult implements RefererResult {
 			refererPath = referer;
 		}
 		String ctxPath = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
+		
+		//if the context path is not in the beggining we should return the entire path
+		//this is useful for proxied app servers which hide the ctx path from url
+		return refererPath.startsWith(ctxPath) ? refererPath.substring(ctxPath.length()) : refererPath;
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -94,19 +94,19 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-		String referer = request.getHeader("Referer");
-		checkState(referer != null, "The Referer header was not specified");
-
-		String refererPath = null;
+	    String referer = request.getHeader("Referer");
+	    checkState(referer != null, "The Referer header was not specified");
+	    
+	    String refererPath = referer;
 		try {
-			refererPath = new URL(referer).getPath();
+		    refererPath = new URL(referer).getPath();
 		} catch(MalformedURLException e) {
-			//Maybe a relative path?
-			refererPath = referer;
+		    //Maybe a relative path?
+		    refererPath = referer;
 		}
-		
-		String ctxPath = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
+
+		String path = request.getContextPath();
+		return refererPath.substring(refererPath.indexOf(path) + path.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -21,6 +21,8 @@ import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 
 import javax.enterprise.context.RequestScoped;
@@ -92,11 +94,19 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-		String referer = request.getHeader("Referer");
-		checkState(referer != null, "The Referer header was not specified");
+	    String referer = request.getHeader("Referer");
+	    checkState(referer != null, "The Referer header was not specified");
+	    
+	    String refererPath = referer;
+		try {
+		    refererPath = new URL(referer).getPath();
+		} catch(MalformedURLException e) {
+		    //Maybe a relative path?
+		    refererPath = referer;
+		}
 
 		String path = request.getContextPath();
-		return referer.substring(referer.indexOf(path) + path.length());
+		return refererPath.substring(refererPath.indexOf(path) + path.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -94,19 +94,19 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-	    String referer = request.getHeader("Referer");
-	    checkState(referer != null, "The Referer header was not specified");
-	    
-	    String refererPath = referer;
-		try {
-		    refererPath = new URL(referer).getPath();
-		} catch(MalformedURLException e) {
-		    //Maybe a relative path?
-		    refererPath = referer;
-		}
+		String referer = request.getHeader("Referer");
+		checkState(referer != null, "The Referer header was not specified");
 
-		String path = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(path) + path.length());
+		String refererPath = null;
+		try {
+			refererPath = new URL(referer).getPath();
+		} catch(MalformedURLException e) {
+			//Maybe a relative path?
+			refererPath = referer;
+		}
+		
+		String ctxPath = request.getContextPath();
+		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
 	}
 
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -153,44 +153,44 @@ public class DefaultRefererResultTest {
 	
 	@Test
     public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
-		
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-		
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-		
-		doReturn(logic).when(result).use(logic());
-		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.redirect();
-		
-		verify(logic).redirectTo(RefererController.class);
-		verify(controller).index();
+        LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.redirect();
+        
+        verify(logic).redirectTo(RefererController.class);
+        verify(controller).index();
     }
 	
 	@Test
 	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
-
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-		
-		doReturn(logic).when(result).use(logic());
-		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.forward();
-		
-		verify(logic).forwardTo(RefererController.class);
-		verify(controller).index();
+	    LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+        
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.forward();
+        
+        verify(logic).forwardTo(RefererController.class);
+        verify(controller).index();
 	}
 	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -150,47 +150,4 @@ public class DefaultRefererResultTest {
 		verify(logic).forwardTo(RefererController.class);
 		verify(controller).index();
 	}
-	
-	@Test
-    public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
-        LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.redirect();
-        
-        verify(logic).redirectTo(RefererController.class);
-        verify(controller).index();
-    }
-	
-	@Test
-	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
-	    LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-        
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.forward();
-        
-        verify(logic).forwardTo(RefererController.class);
-        verify(controller).index();
-	}
-	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -150,4 +150,47 @@ public class DefaultRefererResultTest {
 		verify(logic).forwardTo(RefererController.class);
 		verify(controller).index();
 	}
+	
+	@Test
+    public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
+        LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.redirect();
+        
+        verify(logic).redirectTo(RefererController.class);
+        verify(controller).index();
+    }
+	
+	@Test
+	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
+	    LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+        
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.forward();
+        
+        verify(logic).forwardTo(RefererController.class);
+        verify(controller).index();
+	}
+	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -150,4 +150,47 @@ public class DefaultRefererResultTest {
 		verify(logic).forwardTo(RefererController.class);
 		verify(controller).index();
 	}
+	
+	@Test
+	public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.redirect();
+		
+		verify(logic).redirectTo(RefererController.class);
+		verify(controller).index();
+	}
+
+	@Test
+	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.forward();
+		
+		verify(logic).forwardTo(RefererController.class);
+		verify(controller).index();
+	}
+	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -153,44 +153,44 @@ public class DefaultRefererResultTest {
 	
 	@Test
     public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
-        LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.redirect();
-        
-        verify(logic).redirectTo(RefererController.class);
-        verify(controller).index();
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.redirect();
+		
+		verify(logic).redirectTo(RefererController.class);
+		verify(controller).index();
     }
 	
 	@Test
 	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
-	    LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-        
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.forward();
-        
-        verify(logic).forwardTo(RefererController.class);
-        verify(controller).index();
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.forward();
+		
+		verify(logic).forwardTo(RefererController.class);
+		verify(controller).index();
 	}
 	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -193,4 +193,46 @@ public class DefaultRefererResultTest {
 		verify(controller).index();
 	}
 	
+	@Test
+	public void whenRefererDoesNotContainsCtxPathItShouldRedirectCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.redirect();
+		
+		verify(logic).redirectTo(RefererController.class);
+		verify(controller).index();
+	}
+	
+	@Test
+	public void whenRefererDoesNotContainsCtxPathItShouldForwardCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.forward();
+		
+		verify(logic).forwardTo(RefererController.class);
+		verify(controller).index();
+	}
+	
 }


### PR DESCRIPTION
If the context path string was present in the referer host the getReferer() method returned an invalid referer
